### PR TITLE
Redact sensitive URL data and deduplicate request logs

### DIFF
--- a/config/logger-options.js
+++ b/config/logger-options.js
@@ -29,6 +29,7 @@ const urlLogPaths = [
  * @returns {unknown}
  */
 function redactUrlData (value) {
+  if (value == null) return value
   if (typeof value !== 'string') return '[Redacted]'
 
   if (value.startsWith('/') || /^[a-z][a-z\d+.-]*:\/\//i.test(value)) {

--- a/config/logger-options.js
+++ b/config/logger-options.js
@@ -11,6 +11,63 @@ const PinoLevelToSeverityLookup = /** @type {const} */ ({
   fatal: 'CRITICAL',
 })
 
+const urlLogPaths = [
+  'sourceUrl',
+  'url',
+  'req.url',
+  'err.message',
+  'err.stack',
+  'err.description',
+  'err.cause.message',
+  'err.cause.stack',
+]
+
+/**
+ * Remove URL data that can contain credentials or signatures while retaining
+ * enough stable information to identify the source.
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function redactUrlData (value) {
+  if (typeof value !== 'string') return '[Redacted]'
+
+  if (value.startsWith('/') || /^[a-z][a-z\d+.-]*:\/\//i.test(value)) {
+    return sanitizeUrl(value)
+  }
+
+  return value.replace(/https?:\/\/[^\s]+/gi, url => sanitizeUrl(url))
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function sanitizeUrl (value) {
+  try {
+    const isRelative = value.startsWith('/')
+    const url = new URL(value, 'https://redacted.invalid')
+    const videoId = isYouTubeWatchUrl(url) ? url.searchParams.get('v') : null
+
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    if (videoId) url.searchParams.set('v', videoId)
+
+    return isRelative ? `${url.pathname}${url.search}` : url.toString()
+  } catch {
+    return '[Redacted]'
+  }
+}
+
+/**
+ * @param {URL} url
+ * @returns {boolean}
+ */
+function isYouTubeWatchUrl (url) {
+  return /(^|\.)youtube\.com$/i.test(url.hostname) && url.pathname === '/watch'
+}
+
 export const loggerOptions = /** @type{const} @satisfies {FastifyServerOptions['logger']} */ ({
   mixin () {
     return {
@@ -18,6 +75,10 @@ export const loggerOptions = /** @type{const} @satisfies {FastifyServerOptions['
     }
   },
   messageKey: 'message',
+  redact: {
+    paths: urlLogPaths,
+    censor: redactUrlData,
+  },
   formatters: {
     level (/** @type{string} */label, /** @type{number} */number) {
       return {

--- a/config/logger-options.js
+++ b/config/logger-options.js
@@ -36,7 +36,21 @@ function redactUrlData (value) {
     return sanitizeUrl(value)
   }
 
-  return value.replace(/https?:\/\/[^\s]+/gi, url => sanitizeUrl(url))
+  return value.replace(/https?:\/\/[^\s]+/gi, sanitizeUrlToken)
+}
+
+/**
+ * Preserve punctuation surrounding a URL embedded in prose.
+ * @param {string} value
+ * @returns {string}
+ */
+function sanitizeUrlToken (value) {
+  let urlEnd = value.length
+  while (urlEnd > 0 && /[),.;:!?\]}>'"]/.test(value[urlEnd - 1] ?? '')) {
+    urlEnd--
+  }
+
+  return sanitizeUrl(value.slice(0, urlEnd)) + value.slice(urlEnd)
 }
 
 /**

--- a/config/logger-options.test.js
+++ b/config/logger-options.test.js
@@ -1,0 +1,25 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { loggerOptions } from './logger-options.js'
+
+test('redacts sensitive URL data while preserving YouTube video IDs', () => {
+  const redact = /** @type {Exclude<typeof loggerOptions.redact, string[]>} */ (loggerOptions.redact)
+  const censor = /** @type {(value: unknown) => unknown} */ (redact.censor)
+
+  assert.equal(
+    censor('https://user:password@cdn.example.com/audio.mp3?Signature=secret#token'),
+    'https://cdn.example.com/audio.mp3'
+  )
+  assert.equal(
+    censor('https://www.youtube.com/watch?v=abc123&si=secret'),
+    'https://www.youtube.com/watch?v=abc123'
+  )
+  assert.equal(
+    censor('/unified?url=https%3A%2F%2Fcdn.example.com%2Fa.mp3%3FSignature%3Dsecret'),
+    '/unified'
+  )
+  assert.equal(
+    censor('Unable to download https://cdn.example.com/audio.mp3?Signature=secret HTTP 403'),
+    'Unable to download https://cdn.example.com/audio.mp3 HTTP 403'
+  )
+})

--- a/config/logger-options.test.js
+++ b/config/logger-options.test.js
@@ -6,6 +6,9 @@ test('redacts sensitive URL data while preserving YouTube video IDs', () => {
   const redact = /** @type {Exclude<typeof loggerOptions.redact, string[]>} */ (loggerOptions.redact)
   const censor = /** @type {(value: unknown) => unknown} */ (redact.censor)
 
+  assert.equal(censor(null), null)
+  assert.equal(censor(undefined), undefined)
+  assert.equal(censor({ query: 'secret' }), '[Redacted]')
   assert.equal(
     censor('https://user:password@cdn.example.com/audio.mp3?Signature=secret#token'),
     'https://cdn.example.com/audio.mp3'

--- a/config/logger-options.test.js
+++ b/config/logger-options.test.js
@@ -25,4 +25,8 @@ test('redacts sensitive URL data while preserving YouTube video IDs', () => {
     censor('Unable to download https://cdn.example.com/audio.mp3?Signature=secret HTTP 403'),
     'Unable to download https://cdn.example.com/audio.mp3 HTTP 403'
   )
+  assert.equal(
+    censor('Unable to download (https://cdn.example.com/audio.mp3?Signature=secret), retrying.'),
+    'Unable to download (https://cdn.example.com/audio.mp3), retrying.'
+  )
 })

--- a/routes/discover/routes.js
+++ b/routes/discover/routes.js
@@ -118,7 +118,6 @@ export default async function discoverRoute (fastify, _opts) {
             parentRequestId,
           }))
           request.log.info({
-            parentRequestId,
             sourceUrl: parsedUrl.toString(),
             format,
             endpointType: 'discover',
@@ -132,7 +131,6 @@ export default async function discoverRoute (fastify, _opts) {
 
           request.log.warn({
             err: handledError,
-            parentRequestId,
             sourceUrl: parsedUrl.toString(),
             format,
             endpointType: 'discover',
@@ -183,7 +181,6 @@ export default async function discoverRoute (fastify, _opts) {
 
           if (response.statusCode > 399) {
             request.log.warn({
-              parentRequestId,
               sourceUrl: parsedUrl.toString(),
               format,
               endpointType: 'discover',
@@ -225,7 +222,6 @@ export default async function discoverRoute (fastify, _opts) {
           }
 
           request.log.info({
-            parentRequestId,
             sourceUrl: parsedUrl.toString(),
             format,
             endpointType: 'discover',
@@ -236,7 +232,6 @@ export default async function discoverRoute (fastify, _opts) {
         } catch (err) {
           request.log.error({
             err,
-            parentRequestId,
             sourceUrl: parsedUrl.toString(),
             format,
             endpointType: 'discover',

--- a/routes/unified/routes.js
+++ b/routes/unified/routes.js
@@ -122,7 +122,6 @@ export default async function ytDlpRoute (fastify, _opts) {
           }))
           const mediaUrlDiagnostics = getMediaUrlDiagnostics(results.url)
           request.log.info({
-            parentRequestId,
             sourceUrl: parsedUrl.toString(),
             format,
             endpointType: 'unified',
@@ -137,7 +136,6 @@ export default async function ytDlpRoute (fastify, _opts) {
 
           request.log.warn({
             err: handledError,
-            parentRequestId,
             sourceUrl: parsedUrl.toString(),
             format,
             endpointType: 'unified',
@@ -191,7 +189,6 @@ export default async function ytDlpRoute (fastify, _opts) {
 
           if (response.statusCode > 399) {
             request.log.warn({
-              parentRequestId,
               sourceUrl: parsedUrl.toString(),
               format,
               endpointType: 'unified',
@@ -231,7 +228,6 @@ export default async function ytDlpRoute (fastify, _opts) {
           }
 
           request.log.info({
-            parentRequestId,
             sourceUrl: parsedUrl.toString(),
             format,
             endpointType: 'unified',
@@ -243,7 +239,6 @@ export default async function ytDlpRoute (fastify, _opts) {
         } catch (err) {
           request.log.error({
             err,
-            parentRequestId,
             sourceUrl: parsedUrl.toString(),
             format,
             endpointType: 'unified',


### PR DESCRIPTION
## Summary

- Use Pino redaction to remove credentials, fragments, and query parameters from logged URLs.
- Preserve the YouTube video ID when sanitizing YouTube watch URLs.
- Sanitize incoming request URLs and URLs embedded in serialized errors.
- Avoid repeating parentRequestId in route outcome payloads when request correlation already binds it.
- Continue propagating parentRequestId into Piscina tasks for worker correlation.

This changes logging output only and does not modify source URLs used for extraction or returned media URLs.

## Testing

- npm test
- Verified Pino serialization with signed source URLs, request URLs, and error messages.