### PR TITLE
Log health requests at debug level

### DIFF
--- a/config/server-options.js
+++ b/config/server-options.js
@@ -12,6 +12,7 @@ const fastifyOptions = /** @type{const} @satisfies {Partial<FastifyServerOptions
   pluginTimeout: 30000,
   trustProxy: true,
   genReqId: function (/* req */) { return hid() },
+  disableRequestLogging: request => request.url === '/health',
   logger: loggerOptions,
 })
 

--- a/lib/otel-shutdown.js
+++ b/lib/otel-shutdown.js
@@ -25,8 +25,11 @@ export function registerOtelShutdown (fastify) {
   fastify.addHook('onClose', async function shutdownOtel () {
     if (!otelSdk) return
 
+    const sdk = otelSdk
+    otelSdk = undefined
+
     try {
-      await otelSdk.shutdown()
+      await sdk.shutdown()
       fastify.log.info('OpenTelemetry SDK shut down successfully')
     } catch (err) {
       fastify.log.error({ err }, 'Error shutting down OpenTelemetry SDK')

--- a/lib/otel-shutdown.js
+++ b/lib/otel-shutdown.js
@@ -1,0 +1,35 @@
+/** @import { FastifyInstance } from 'fastify' */
+
+/**
+ * @typedef {object} OtelSdk
+ * @property {() => Promise<void>} shutdown
+ */
+
+/** @type {OtelSdk | undefined} */
+let otelSdk
+
+/**
+ * Make the SDK created by the process preload available to the Fastify lifecycle.
+ * Tests that do not preload OpenTelemetry leave this value undefined.
+ * @param {OtelSdk | undefined} sdk
+ */
+export function setOtelSdk (sdk) {
+  otelSdk = sdk
+}
+
+/**
+ * Shut down the preloaded OpenTelemetry SDK with the application logger.
+ * @param {FastifyInstance} fastify
+ */
+export function registerOtelShutdown (fastify) {
+  fastify.addHook('onClose', async function shutdownOtel () {
+    if (!otelSdk) return
+
+    try {
+      await otelSdk.shutdown()
+      fastify.log.info('OpenTelemetry SDK shut down successfully')
+    } catch (err) {
+      fastify.log.error({ err }, 'Error shutting down OpenTelemetry SDK')
+    }
+  })
+}

--- a/lib/otel-shutdown.test.js
+++ b/lib/otel-shutdown.test.js
@@ -1,0 +1,21 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import Fastify from 'fastify'
+import { registerOtelShutdown, setOtelSdk } from './otel-shutdown.js'
+
+test('registerOtelShutdown closes the preloaded SDK with Fastify', async () => {
+  let shutdownCalls = 0
+  setOtelSdk({
+    async shutdown () {
+      shutdownCalls++
+    },
+  })
+  const app = Fastify({ logger: false })
+  registerOtelShutdown(app)
+  await app.ready()
+
+  await app.close()
+  setOtelSdk(undefined)
+
+  assert.equal(shutdownCalls, 1)
+})

--- a/lib/otel-shutdown.test.js
+++ b/lib/otel-shutdown.test.js
@@ -15,7 +15,11 @@ test('registerOtelShutdown closes the preloaded SDK with Fastify', async () => {
   await app.ready()
 
   await app.close()
-  setOtelSdk(undefined)
+
+  const secondApp = Fastify({ logger: false })
+  registerOtelShutdown(secondApp)
+  await secondApp.ready()
+  await secondApp.close()
 
   assert.equal(shutdownCalls, 1)
 })

--- a/otel.js
+++ b/otel.js
@@ -6,6 +6,7 @@ import { FastifyOtelInstrumentation } from '@fastify/otel'
 import { RuntimeNodeInstrumentation } from '@opentelemetry/instrumentation-runtime-node'
 import { HostMetrics } from '@opentelemetry/host-metrics'
 import { metrics } from '@opentelemetry/api'
+import { setOtelSdk } from '#lib/otel-shutdown.js'
 
 const sentryDsn = process.env['SENTRY_DSN']
 const sentryEnvironment = process.env['SENTRY_ENVIRONMENT'] ?? process.env['ENV'] ?? process.env['NODE_ENV']
@@ -51,14 +52,6 @@ export const sdk = new NodeSDK({
 })
 
 sdk.start()
+setOtelSdk(sdk)
 // Must come after sdk.start() for getMeterProvider to return something
 new HostMetrics({ meterProvider: metrics.getMeterProvider() }).start()
-
-process.on('SIGTERM', () => {
-  sdk
-    .shutdown()
-    .then(
-      () => console.log('SDK shut down successfully'),
-      (err) => console.log(new Error('Error shutting down SDK', { cause: err }))
-    )
-})

--- a/plugins/health.js
+++ b/plugins/health.js
@@ -1,7 +1,17 @@
 import fp from 'fastify-plugin'
 
 export default fp(async function (fastify, _opts) {
-  fastify.get('/health', async function () {
+  fastify.get('/health', {
+    onRequest: async function logHealthRequest (request) {
+      request.log.debug({ req: request }, 'incoming request')
+    },
+    onResponse: async function logHealthResponse (_request, reply) {
+      reply.log.debug({
+        res: reply,
+        responseTime: reply.elapsedTime,
+      }, 'request completed')
+    },
+  }, async function () {
     return { statusCode: 200, status: 'ok' }
   })
 }, {

--- a/plugins/health.test.js
+++ b/plugins/health.test.js
@@ -1,6 +1,9 @@
 import { test } from 'node:test'
 import * as assert from 'node:assert'
+import Fastify from 'fastify'
 import { build } from '../test/helper.js'
+import { options } from '../config/server-options.js'
+import health from './health.js'
 
 test('healthcheck baseline test', async (t) => {
   const app = await build(t)
@@ -8,4 +11,35 @@ test('healthcheck baseline test', async (t) => {
     url: '/health',
   })
   assert.equal(res.payload, '{"statusCode":200,"status":"ok"}')
+})
+
+test('healthcheck request logs use debug level', async (t) => {
+  /** @type {Array<{level?: number, msg?: string, reqId?: string}>} */
+  const records = []
+  const stream = {
+    write (/** @type {string} */ line) {
+      records.push(JSON.parse(line))
+    },
+  }
+  const app = Fastify({
+    disableRequestLogging: options.disableRequestLogging,
+    logger: {
+      level: 'trace',
+      stream,
+    },
+  })
+  t.after(() => app.close())
+  await app.register(health)
+
+  await app.inject({ url: '/health' })
+
+  assert.deepEqual(
+    records
+      .filter(record => record.reqId)
+      .map(record => ({ level: record.level, message: record.msg })),
+    [
+      { level: 20, message: 'incoming request' },
+      { level: 20, message: 'request completed' },
+    ]
+  )
 })

--- a/plugins/onesie-pool.test.js
+++ b/plugins/onesie-pool.test.js
@@ -18,7 +18,6 @@ async function testByteRange (url, byteLength = 128) {
   })
 
   const statusCode = res.statusCode
-  console.log({ statusCode })
   const statusOk = statusCode === 206 || statusCode === 200
   assert.ok(statusOk, 'Correct status code received')
 
@@ -45,8 +44,6 @@ test('youtubei decorator onesieFormatRequest test', { todo: process.env.CI }, as
     returnRedirectUrl: true
   })
 
-  console.log({ url: result.url })
-
   // Assert expected values
   assert.strictEqual(result.title, 'bitch lasagna')
   assert.strictEqual(result.duration, 135)
@@ -65,9 +62,6 @@ test('youtubei decorator onesieFormatRequest test', { todo: process.env.CI }, as
   // Byte-range validation with user-agent (skip in CI)
   if (!process.env['CI']) {
     await sleep(3000)
-    const byteRangeData = await testByteRange(result.url)
-    console.log('Byte-range check passed:', byteRangeData.byteLength, 'bytes received')
-  } else {
-    console.log('Skipping byte-range check in CI environment')
+    await testByteRange(result.url)
   }
 })

--- a/plugins/otel-shutdown.js
+++ b/plugins/otel-shutdown.js
@@ -1,0 +1,8 @@
+import fp from 'fastify-plugin'
+import { registerOtelShutdown } from '#lib/otel-shutdown.js'
+
+export default fp(async function otelShutdown (fastify) {
+  registerOtelShutdown(fastify)
+}, {
+  name: 'otel-shutdown',
+})


### PR DESCRIPTION
## Summary

- Disable Fastify automatic request logging only for the exact /health path.
- Emit equivalent health request and completion records at debug level.
- Move OpenTelemetry shutdown into a Fastify onClose hook so shutdown success and errors use fastify.log.
- Remove loose console output from the live Onesie test while retaining assertions.

## Audit result

No console calls remain in normal yt-dlp-api Fastify runtime paths.

Standalone probe scripts retain console output because terminal output is their interface.

## Testing

- Isolated health logging regression passes.
- OpenTelemetry shutdown lifecycle test passes.
- ESLint passes.
- TypeScript passes.
- The existing full-app health baseline is currently blocked by the worktree installation failing to resolve ioredis before route startup.