### PR TITLE
Fix Python subprocess shutdown

### DIFF
--- a/fixtures/python-shutdown-app.js
+++ b/fixtures/python-shutdown-app.js
@@ -1,0 +1,18 @@
+import { envSchema } from '../config/env-schema.js'
+import envPlugin from '../plugins/env.js'
+import ytDlpServerPlugin from '../plugins/yt-dlp-server.js'
+
+/**
+ * @import { FastifyPluginAsync } from 'fastify'
+ */
+
+/** @type {FastifyPluginAsync} */
+export default async function PythonShutdownApp (fastify, _opts) {
+  fastify.addSchema(envSchema)
+  fastify.register(envPlugin, {
+    envData: {
+      YTDLPAPI_HOST: '127.0.0.1:3911',
+    },
+  })
+  fastify.register(ytDlpServerPlugin)
+}

--- a/fixtures/subprocess.js
+++ b/fixtures/subprocess.js
@@ -1,0 +1,18 @@
+const mode = process.argv[2]
+const keepAlive = setInterval(() => {}, 1000)
+
+if (mode === 'graceful') {
+  process.on('SIGTERM', () => {
+    clearInterval(keepAlive)
+    process.exit(0)
+  })
+} else if (mode === 'ignore') {
+  process.on('SIGTERM', () => {})
+} else if (mode === 'exit') {
+  clearInterval(keepAlive)
+  process.exit(0)
+} else {
+  throw new Error(`Unknown subprocess fixture mode: ${mode}`)
+}
+
+if (process.send) process.send({ ready: true })

--- a/fly.toml
+++ b/fly.toml
@@ -22,6 +22,7 @@ swap_size_mb = 1024
   PORT = "3010"
   FASTIFY_ADDRESS = "0.0.0.0"
   FASTIFY_LOG_LEVEL = "info"
+  FASTIFY_CLOSE_GRACE_DELAY = "4500"
   FASTIFY_OPTIONS = "true"
   METRICS = "true"
   FASTIFY_IMPORT = "./otel.js"

--- a/lib/shutdown-subprocess.js
+++ b/lib/shutdown-subprocess.js
@@ -1,0 +1,260 @@
+import { performance } from 'node:perf_hooks'
+
+/**
+ * @import { ChildProcess } from 'node:child_process'
+ */
+
+const completedShutdowns = new WeakMap()
+
+/**
+ * @typedef {Object} SubprocessLogger
+ * @property {(context: object, message: string) => void} info
+ * @property {(context: object, message: string) => void} warn
+ * @property {(context: object, message: string) => void} [error]
+ */
+
+/**
+ * @typedef {Object} ShutdownResult
+ * @property {number | undefined} pid
+ * @property {number | null} code
+ * @property {NodeJS.Signals | null} signal
+ * @property {number} elapsedMs
+ * @property {boolean} forceKillRequired
+ */
+
+/**
+ * Shut down a direct child and force-kill its process group if it does not exit.
+ *
+ * The child must have been spawned with `detached: true` for the process-group
+ * kill to include descendants.
+ *
+ * @param {Object} options
+ * @param {ChildProcess} options.child
+ * @param {SubprocessLogger} options.logger
+ * @param {number} options.gracefulTimeoutMs
+ * @param {number} [options.forceKillTimeoutMs]
+ * @returns {Promise<ShutdownResult>}
+ */
+export function shutdownSubprocess ({
+  child,
+  logger,
+  gracefulTimeoutMs,
+  forceKillTimeoutMs = 500,
+}) {
+  const existingShutdown = completedShutdowns.get(child)
+  if (existingShutdown) return existingShutdown
+
+  const shutdown = performShutdown({
+    child,
+    logger,
+    gracefulTimeoutMs,
+    forceKillTimeoutMs,
+  })
+  completedShutdowns.set(child, shutdown)
+  return shutdown
+}
+
+/**
+ * @param {Object} options
+ * @param {() => Promise<void>} options.start
+ * @param {SubprocessLogger} options.logger
+ * @param {number} options.maxAttempts
+ * @param {number} options.restartDelayMs
+ */
+export function createSubprocessRestarter ({
+  start,
+  logger,
+  maxAttempts,
+  restartDelayMs,
+}) {
+  let attempts = 0
+  let isShuttingDown = false
+  /** @type {NodeJS.Timeout | null} */
+  let restartTimer = null
+  /** @type {(() => void) | null} */
+  let cancelRestartWait = null
+
+  return {
+    /**
+     * @param {Object} options
+     * @param {boolean} options.expected
+     */
+    async handleExit ({ expected }) {
+      if (expected || isShuttingDown) return
+
+      if (attempts >= maxAttempts) {
+        logger.error?.({ attempts, maxAttempts }, 'Maximum subprocess restart attempts reached')
+        return
+      }
+
+      attempts++
+      logger.warn({ attempt: attempts, maxAttempts }, 'Attempting to restart subprocess')
+
+      await new Promise(resolve => {
+        cancelRestartWait = resolve
+        restartTimer = setTimeout(resolve, restartDelayMs * attempts)
+      })
+      restartTimer = null
+      cancelRestartWait = null
+
+      if (isShuttingDown) return
+
+      try {
+        await start()
+        attempts = 0
+      } catch (err) {
+        logger.error?.({ err }, 'Failed to restart subprocess')
+      }
+    },
+    shutdown () {
+      isShuttingDown = true
+      if (restartTimer) clearTimeout(restartTimer)
+      if (cancelRestartWait) cancelRestartWait()
+      restartTimer = null
+      cancelRestartWait = null
+    },
+    reset () {
+      attempts = 0
+    },
+  }
+}
+
+/**
+ * @param {Object} options
+ * @param {ChildProcess} options.child
+ * @param {SubprocessLogger} options.logger
+ * @param {number} options.gracefulTimeoutMs
+ * @param {number} options.forceKillTimeoutMs
+ * @returns {Promise<ShutdownResult>}
+ */
+async function performShutdown ({
+  child,
+  logger,
+  gracefulTimeoutMs,
+  forceKillTimeoutMs,
+}) {
+  const startedAt = performance.now()
+  const pid = child.pid
+
+  if (hasExited(child)) {
+    return shutdownResult(child, pid, startedAt, false)
+  }
+
+  const exitPromise = waitForExit(child)
+  const signalSent = child.kill('SIGTERM')
+
+  logger.info({
+    pid,
+    signal: 'SIGTERM',
+    signalSent,
+    gracefulTimeoutMs,
+  }, 'Sent graceful shutdown signal to subprocess')
+
+  const exitedGracefully = signalSent && await waitWithTimeout(exitPromise, gracefulTimeoutMs)
+  if (exitedGracefully || hasExited(child)) {
+    const result = shutdownResult(child, pid, startedAt, false)
+    logger.info(result, 'Subprocess shutdown completed')
+    return result
+  }
+
+  const forceSignalSent = killProcessGroup(child, 'SIGKILL')
+  logger.warn({
+    pid,
+    signal: 'SIGKILL',
+    signalSent: forceSignalSent,
+    elapsedMs: elapsed(startedAt),
+  }, 'Force killing subprocess group after graceful shutdown timeout')
+
+  const forceKilled = await waitWithTimeout(exitPromise, forceKillTimeoutMs)
+  if (!forceKilled && !hasExited(child)) {
+    throw new Error(`Subprocess ${pid ?? 'with unknown PID'} did not exit after SIGKILL`)
+  }
+
+  const result = shutdownResult(child, pid, startedAt, true)
+  logger.info(result, 'Subprocess shutdown completed')
+  return result
+}
+
+/**
+ * @param {ChildProcess} child
+ * @returns {Promise<void>}
+ */
+function waitForExit (child) {
+  if (hasExited(child)) return Promise.resolve()
+
+  return new Promise((resolve) => {
+    child.once('exit', resolve)
+
+    if (hasExited(child)) {
+      child.removeListener('exit', resolve)
+      resolve()
+    }
+  })
+}
+
+/**
+ * @param {Promise<void>} exitPromise
+ * @param {number} timeoutMs
+ * @returns {Promise<boolean>}
+ */
+function waitWithTimeout (exitPromise, timeoutMs) {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve(false), timeoutMs)
+
+    exitPromise.then(() => {
+      clearTimeout(timeout)
+      resolve(true)
+    })
+  })
+}
+
+/**
+ * @param {ChildProcess} child
+ * @param {NodeJS.Signals} signal
+ * @returns {boolean}
+ */
+function killProcessGroup (child, signal) {
+  if (child.pid !== undefined) {
+    try {
+      process.kill(-child.pid, signal)
+      return true
+    } catch (err) {
+      if (/** @type {NodeJS.ErrnoException} */ (err).code !== 'ESRCH') throw err
+    }
+  }
+
+  return child.kill(signal)
+}
+
+/**
+ * @param {ChildProcess} child
+ * @returns {boolean}
+ */
+function hasExited (child) {
+  return child.exitCode !== null || child.signalCode !== null
+}
+
+/**
+ * @param {ChildProcess} child
+ * @param {number | undefined} pid
+ * @param {number} startedAt
+ * @param {boolean} forceKillRequired
+ * @returns {ShutdownResult}
+ */
+function shutdownResult (child, pid, startedAt, forceKillRequired) {
+  return {
+    pid,
+    code: child.exitCode,
+    signal: child.signalCode,
+    elapsedMs: elapsed(startedAt),
+    forceKillRequired,
+  }
+}
+
+/**
+ * @param {number} startedAt
+ * @returns {number}
+ */
+function elapsed (startedAt) {
+  return Math.round(performance.now() - startedAt)
+}

--- a/lib/shutdown-subprocess.test.js
+++ b/lib/shutdown-subprocess.test.js
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict'
+import { fork } from 'node:child_process'
+import { EventEmitter, once } from 'node:events'
+import { test } from 'node:test'
+import { createSubprocessRestarter, shutdownSubprocess } from './shutdown-subprocess.js'
+
+const fixturePath = new URL('../fixtures/subprocess.js', import.meta.url)
+const logger = {
+  info () {},
+  warn () {},
+  error () {},
+}
+
+/**
+ * @param {import('node:test').TestContext} t
+ * @param {'graceful' | 'ignore' | 'exit'} mode
+ */
+async function startFixture (t, mode) {
+  const child = fork(fixturePath, [mode], {
+    detached: true,
+    stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+  })
+
+  t.after(async () => {
+    if (child.exitCode === null && child.signalCode === null) {
+      try {
+        process.kill(-(child.pid ?? 0), 'SIGKILL')
+      } catch (err) {
+        if (/** @type {NodeJS.ErrnoException} */ (err).code !== 'ESRCH') throw err
+      }
+      await once(child, 'exit')
+    }
+  })
+
+  if (mode !== 'exit') await once(child, 'message')
+  return child
+}
+
+test('gracefully shuts down a subprocess after SIGTERM', async (t) => {
+  const child = await startFixture(t, 'graceful')
+  const baselineExitListeners = child.listenerCount('exit')
+
+  const result = await shutdownSubprocess({
+    child,
+    logger,
+    gracefulTimeoutMs: 500,
+  })
+
+  assert.equal(result.code, 0)
+  assert.equal(result.signal, null)
+  assert.equal(result.forceKillRequired, false)
+  assert.equal(child.listenerCount('exit'), baselineExitListeners)
+})
+
+test('force kills the subprocess group after the graceful timeout', async (t) => {
+  const child = await startFixture(t, 'ignore')
+
+  const result = await shutdownSubprocess({
+    child,
+    logger,
+    gracefulTimeoutMs: 25,
+  })
+
+  assert.equal(result.code, null)
+  assert.equal(result.signal, 'SIGKILL')
+  assert.equal(result.forceKillRequired, true)
+})
+
+test('handles a subprocess that exits before or during shutdown setup', async (t) => {
+  const child = await startFixture(t, 'exit')
+  await once(child, 'exit')
+
+  const result = await shutdownSubprocess({
+    child,
+    logger,
+    gracefulTimeoutMs: 25,
+  })
+
+  assert.equal(result.code, 0)
+  assert.equal(result.forceKillRequired, false)
+})
+
+test('handles exit while kill returns false', async () => {
+  const fakeChild = new EventEmitter()
+  Object.assign(fakeChild, {
+    pid: undefined,
+    exitCode: null,
+    signalCode: null,
+    kill () {
+      fakeChild.exitCode = 0
+      fakeChild.emit('exit', 0, null)
+      return false
+    },
+  })
+
+  const result = await shutdownSubprocess({
+    child: /** @type {import('node:child_process').ChildProcess} */ (/** @type {unknown} */ (fakeChild)),
+    logger,
+    gracefulTimeoutMs: 25,
+  })
+
+  assert.equal(result.code, 0)
+  assert.equal(result.forceKillRequired, false)
+  assert.equal(fakeChild.listenerCount('exit'), 0)
+})
+
+test('restarts after an unexpected exit but not an expected shutdown', async () => {
+  let starts = 0
+  const restarter = createSubprocessRestarter({
+    start: async () => { starts++ },
+    logger,
+    maxAttempts: 3,
+    restartDelayMs: 0,
+  })
+
+  await restarter.handleExit({ expected: true })
+  assert.equal(starts, 0)
+
+  await restarter.handleExit({ expected: false })
+  assert.equal(starts, 1)
+})
+
+test('cancels a pending unexpected-exit restart during shutdown', async () => {
+  let starts = 0
+  const restarter = createSubprocessRestarter({
+    start: async () => { starts++ },
+    logger,
+    maxAttempts: 3,
+    restartDelayMs: 1000,
+  })
+
+  const restart = restarter.handleExit({ expected: false })
+  restarter.shutdown()
+  await restart
+
+  assert.equal(starts, 0)
+})
+
+test('coalesces repeated shutdown calls', async (t) => {
+  const child = await startFixture(t, 'graceful')
+
+  const firstShutdown = shutdownSubprocess({
+    child,
+    logger,
+    gracefulTimeoutMs: 500,
+  })
+  const secondShutdown = shutdownSubprocess({
+    child,
+    logger,
+    gracefulTimeoutMs: 500,
+  })
+
+  assert.equal(firstShutdown, secondShutdown)
+  const [firstResult, secondResult] = await Promise.all([firstShutdown, secondShutdown])
+  assert.deepEqual(firstResult, secondResult)
+})

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "test:pyright": "pyright -p ytdlp-server",
     "test:node-test": "node --test --test-concurrency=1 --test-reporter=dot",
     "watch": "FORCE_COLOR=1 run-p -n -l watch:*",
-    "watch:fastify": "fastify start -w --ignore-watch='node_modules .git ytdlp-server patches test scripts .github .vscode .zed pnpm-lock.yaml CHANGELOG.md' -l info -P -p 3010 --options --address localhost --import ./otel.js app.js",
+    "watch:fastify": "fastify start -w --ignore-watch='node_modules .git ytdlp-server patches test scripts .github .vscode .zed pnpm-lock.yaml CHANGELOG.md' -g 4500 -l info -P -p 3010 --options --address localhost --import ./otel.js app.js",
     "python-dev": "cd ytdlp-server/ && . venv/bin/activate && flask --app yt_dlp_api --debug run --port 3011",
     "print-routes": "fastify print-routes --import ./otel.js app.js",
     "print-plugins": "fastify print-plugins --import ./otel.js app.js",

--- a/plugins/yt-dlp-server.js
+++ b/plugins/yt-dlp-server.js
@@ -1,7 +1,8 @@
 import fp from 'fastify-plugin'
 import { spawn } from 'node:child_process'
-import { once } from 'node:events'
+
 import { join, resolve } from 'node:path'
+import { createSubprocessRestarter, shutdownSubprocess } from '../lib/shutdown-subprocess.js'
 
 /**
  * @import { ChildProcessByStdio } from 'node:child_process'
@@ -34,9 +35,8 @@ export default fp(async function (fastify, _opts) {
   /** @type {ChildProcessByStdio<null, Readable, Readable> | null} */
   let pythonProcess = null
   let isShuttingDown = false
-  let restartAttempts = 0
-  const maxRestartAttempts = 3
-  const restartDelay = 1000 // 1 second
+  const expectedExits = new WeakSet()
+  const gracefulShutdownTimeoutMs = 3000
 
   const startPythonServer = async () => {
     if (isShuttingDown) return
@@ -72,7 +72,7 @@ export default fp(async function (fastify, _opts) {
         '--workers', '1',
         '--threads', '2',
         '--timeout', '120',
-        '--graceful-timeout', '30',
+        '--graceful-timeout', '3',
         '--keep-alive', '5',
         '--log-level', 'info',
         '--access-logfile', '-',
@@ -83,12 +83,15 @@ export default fp(async function (fastify, _opts) {
       {
         cwd: ytdlpServerDir,
         env,
+        detached: true,
         stdio: ['ignore', 'pipe', 'pipe']
       }
     )
 
+    const child = pythonProcess
+
     // Handle stdout
-    pythonProcess.stdout.on('data', (data) => {
+    child.stdout.on('data', (data) => {
       // @ts-expect-error
       const lines = data.toString().split('\n').filter(line => line.trim())
       // @ts-expect-error
@@ -98,7 +101,7 @@ export default fp(async function (fastify, _opts) {
     })
 
     // Handle stderr
-    pythonProcess.stderr.on('data', (data) => {
+    child.stderr.on('data', (data) => {
       // @ts-expect-error
       const lines = data.toString().split('\n').filter(line => line.trim())
       // @ts-expect-error
@@ -115,35 +118,23 @@ export default fp(async function (fastify, _opts) {
     })
 
     // Handle process exit
-    pythonProcess.on('exit', async (code, signal) => {
-      fastify.log.info({ code, signal, service: 'yt-dlp-server' }, 'Python server exited')
-      pythonProcess = null
+    child.on('exit', async (code, signal) => {
+      const expected = isShuttingDown || expectedExits.has(child)
+      fastify.log.info({
+        pid: child.pid,
+        code,
+        signal,
+        expected,
+        service: 'yt-dlp-server',
+      }, expected ? 'Python server stopped' : 'Python server exited unexpectedly')
 
-      // Attempt restart if not shutting down and within retry limits
-      if (!isShuttingDown && restartAttempts < maxRestartAttempts) {
-        restartAttempts++
-        fastify.log.warn(
-          { attempt: restartAttempts, maxAttempts: maxRestartAttempts },
-          'Attempting to restart Python server'
-        )
+      if (pythonProcess === child) pythonProcess = null
 
-        // Wait before restarting
-        await new Promise(resolve => setTimeout(resolve, restartDelay * restartAttempts))
-
-        try {
-          await startPythonServer()
-          // Reset attempts on successful restart
-          restartAttempts = 0
-        } catch (err) {
-          fastify.log.error({ err }, 'Failed to restart Python server')
-        }
-      } else if (restartAttempts >= maxRestartAttempts) {
-        fastify.log.error('Maximum restart attempts reached for Python server')
-      }
+      await restarter.handleExit({ expected })
     })
 
     // Handle process errors
-    pythonProcess.on('error', (err) => {
+    child.on('error', (err) => {
       fastify.log.error({ err, service: 'yt-dlp-server' }, 'Python server process error')
     })
 
@@ -154,51 +145,61 @@ export default fp(async function (fastify, _opts) {
     fastify.log.info({ bindAddress }, 'yt-dlp Python server started')
   }
 
-  // Start the Python server
-  try {
-    await startPythonServer()
-  } catch (err) {
-    fastify.log.error({ err }, 'Failed to start Python server')
-    throw err
-  }
+  const restarter = createSubprocessRestarter({
+    start: startPythonServer,
+    logger: fastify.log,
+    maxAttempts: 3,
+    restartDelayMs: 1000,
+  })
+
+  // Start only after every plugin has loaded so a later startup failure cannot
+  // orphan a Python process before shutdown hooks become active.
+  fastify.addHook('onReady', async () => {
+    try {
+      await startPythonServer()
+    } catch (err) {
+      fastify.log.error({ err }, 'Failed to start Python server')
+      throw err
+    }
+  })
 
   // Graceful shutdown
   fastify.addHook('onClose', async (instance) => {
     isShuttingDown = true
 
-    if (pythonProcess) {
-      instance.log.info('Shutting down yt-dlp Python server')
+    restarter.shutdown()
 
-      // Send SIGTERM for graceful shutdown
-      pythonProcess.kill('SIGTERM')
+    const child = pythonProcess
+    if (!child) return
 
-      try {
-        // Wait for process to exit (with timeout)
-        await Promise.race([
-          once(pythonProcess, 'exit'),
-          // eslint-disable-next-line promise/param-names
-          new Promise((_, reject) =>
-            setTimeout(() => reject(new Error('Shutdown timeout')), 10000)
-          )
-        ])
-      } catch (err) {
-        // Force kill if graceful shutdown fails
-        instance.log.warn('Force killing Python server due to shutdown timeout')
-        pythonProcess.kill('SIGKILL')
-      }
-    }
+    expectedExits.add(child)
+    instance.log.info({ pid: child.pid }, 'Shutting down yt-dlp Python server')
+    await shutdownSubprocess({
+      child,
+      logger: instance.log,
+      gracefulTimeoutMs: gracefulShutdownTimeoutMs,
+    })
   })
 
   // Decorate fastify with Python process info for debugging
   fastify.decorate('pythonServer', {
     get pid () { return pythonProcess?.pid },
-    get running () { return pythonProcess !== null && !pythonProcess.killed },
+    get running () {
+      return pythonProcess !== null &&
+        pythonProcess.exitCode === null &&
+        pythonProcess.signalCode === null
+    },
     restart: async () => {
-      if (pythonProcess) {
-        pythonProcess.kill('SIGTERM')
-        await once(pythonProcess, 'exit')
+      const child = pythonProcess
+      if (child) {
+        expectedExits.add(child)
+        await shutdownSubprocess({
+          child,
+          logger: fastify.log,
+          gracefulTimeoutMs: gracefulShutdownTimeoutMs,
+        })
       }
-      restartAttempts = 0
+      restarter.reset()
       await startPythonServer()
     }
   })


### PR DESCRIPTION
## Summary

- make Gunicorn shutdown race-safe and idempotent
- force-kill the detached process group after a bounded graceful timeout
- distinguish expected shutdowns from crashes and cancel pending restarts
- align Gunicorn, Fastify CLI, and Fly shutdown budgets
- defer Python startup until Fastify is ready to prevent startup-failure orphans

## Root cause

Fastify CLI uses close-with-grace with a 500 ms default deadline. It emitted `killed by timeout (500ms)` and called `process.exit(1)` while the Python onClose hook was still awaiting Gunicorn. The previous hook also attached its exit waiter after signaling and reused mutable child state.

## Validation

- `node --test lib/shutdown-subprocess.test.js` — 7 passed
- `CI=true pnpm test` — ESLint, TypeScript, Pyright, and 51 Node tests passed
- real Fastify CLI/Gunicorn SIGINT reproduction — Gunicorn worker and parent exited, Node exited 0 in 237 ms, and no Python process remained

## Deployment configuration

This sets `FASTIFY_CLOSE_GRACE_DELAY=4500` in `fly.toml`; deploy that configuration with the code.